### PR TITLE
Fix yosys build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,7 @@ GHDL_MODULE = -mghdl
 	$(YOSYS) $(GHDL_MODULE) -q -l synth.log \
 	-p "ghdl --std=08 --ieee=synopsys ${VHDL_FILES} -e t65" \
 	-p "read_verilog -sv ${VERILOG_FILES}" \
-	-p "hierarchy -top top" \
-	-p "synth_ecp5 ${YOSYS_OPTIONS} -json $@"
+	-p "synth_ecp5 -top top ${YOSYS_OPTIONS} -json $@"
 
 %_out.config: %.json
 	$(NEXTPNR-ECP5) $(NEXTPNR_OPTIONS) --json  $< --textcfg $@ --$(FPGA_KS) --freq 21 --package CABGA381 --lpf ulx3s_v20.lpf

--- a/top.v
+++ b/top.v
@@ -66,6 +66,7 @@ module top
   wire  btn_down  =  btn[4];
   wire  btn_left  =  btn[5];
   wire  btn_right =  btn[6];
+  wire  btn_select = btn_start & btn_a;
 
 
   // passthru to ESP32 micropython serial console
@@ -397,10 +398,6 @@ module top
 
   wire reset_nes = (!load_done || init_reset || download_reset || sys_reset) ;
   wire [1:0] nes_ce;
-
-  // select button is not functional
-  // as we don't have any onboard buttons left on the board
-  wire btn_select = 1'b0;
 
   reg last_joypad_clock;
   reg [7:0] joypad_bits;


### PR DESCRIPTION
The yosys hierarchy pass causes generics to be resolved and generates a new cell. In turn the original cell is removed. Running hierarchy twice, once explicitly in the Makefile and second as part of the synth_ecp5 pass, causes yosys synthesis to fail, as the original module cannot be found. I don't know whether this is a bug in yosys, but this commit fixes the build.

Also make select button usable.